### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2E Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/thecybersailor/slauth/security/code-scanning/15](https://github.com/thecybersailor/slauth/security/code-scanning/15)

To fix the problem, you should explicitly add a `permissions:` block to restrict the GITHUB_TOKEN permissions for the workflow. Since the jobs are only checking out code (`actions/checkout`) and uploading artifacts (`actions/upload-artifact`), the minimal required scope is likely `contents: read`. This can be set either at the workflow root (which applies to all jobs unless overridden) or per-job. Because there is only one job, and CodeQL recommended setting it at the root, you should add the following at the top level of `.github/workflows/e2e.yml` (just after the workflow `name:` if present, and before the `on:` block):

```yaml
permissions:
  contents: read
```
This restricts the `GITHUB_TOKEN` by default in all jobs to only allow read-access to repository contents, avoiding unintentional write access. 

No imports or new libraries are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
